### PR TITLE
fix: speed up cairo-runner and cairo-tester in starklings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ name = "starklings"
 path = "src/main.rs"
 
 [[bin]]
-name = "cairo-runner"
-path = "src/cairo-runner.rs"
+name = "starklings-runner"
+path = "src/starklings_runner.rs"
 
 [[bin]]
-name = "cairo-tester"
-path = "src/cairo-tester.rs"
+name = "starklings-tester"
+path = "src/starklings_tester.rs"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 0. Make sure you have Rust and Cargo installed with `nightly` toolchain. With rustup,
    - `curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly`
    - Or `Customise installation` then `Default toolchain?` set to `nightly` and everything else empty.
-1. Run `cargo run --bin starklings`, this might take a while the first time.
-2. You should see an intro message a little like this.
-
+1. Run `cargo build --all --release`, this might take a while the first time.
+2. Run `target/release/starklings watch` to start the interactive tutorial.
+3. Run `target/release/starklings --help` for more options.
 ```
 starklings - An interactive tutorial to get started with Cairo and Starknet
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 0. Make sure you have Rust and Cargo installed with `nightly` toolchain. With rustup,
    - `curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly`
    - Or `Customise installation` then `Default toolchain?` set to `nightly` and everything else empty.
-1. Run `cargo build --all --release`, this might take a while the first time.
-2. Run `target/release/starklings watch` to start the interactive tutorial.
-3. Run `target/release/starklings --help` for more options.
+1. Run `cargo build --all`, this might take a while the first time.
+2. Run `target/debug/starklings watch` to start the interactive tutorial.
+3. Run `target/debug/starklings --help` for more options.
 ```
 starklings - An interactive tutorial to get started with Cairo and Starknet
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 0. Make sure you have Rust and Cargo installed with `nightly` toolchain. With rustup,
    - `curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly`
    - Or `Customise installation` then `Default toolchain?` set to `nightly` and everything else empty.
-1. Run `cargo build --all`, this might take a while the first time.
-2. Run `target/debug/starklings watch` to start the interactive tutorial.
-3. Run `target/debug/starklings --help` for more options.
+1. Run `cargo run --bin starklings`, this might take a while the first time.
+2. You should see an intro message a little like this.
+
 ```
 starklings - An interactive tutorial to get started with Cairo and Starknet
 

--- a/info.toml
+++ b/info.toml
@@ -2,25 +2,25 @@
 
 [[exercises]]
 name = "intro1"
-path = "solutions/intro/intro1.cairo"
+path = "exercises/intro/intro1.cairo"
 mode = "compile"
 hint = """"""
 
 [[exercises]]
 name = "intro2"
-path = "solutions/intro/intro2.cairo"
+path = "exercises/intro/intro2.cairo"
 mode = "compile"
 hint = """"""
 
 [[exercises]]
 name = "intro3"
-path = "solutions/intro/intro3.cairo"
+path = "exercises/intro/intro3.cairo"
 mode = "compile"
 hint = """"""
 
 [[exercises]]
 name = "intro4"
-path = "solutions/intro/intro4.cairo"
+path = "exercises/intro/intro4.cairo"
 mode = "compile"
 hint = """"""
 
@@ -28,7 +28,7 @@ hint = """"""
 
 [[exercises]]
 name = "variables1"
-path = "solutions/variables/variables1.cairo"
+path = "exercises/variables/variables1.cairo"
 mode = "compile"
 hint = """
 The declaration on line 8 is missing a keyword that is needed in Cairo
@@ -36,7 +36,7 @@ to create a new variable binding."""
 
 [[exercises]]
 name = "variables2"
-path = "solutions/variables/variables2.cairo"
+path = "exercises/variables/variables2.cairo"
 mode = "compile"
 hint = """
 What happens if you annotate line 7 with a type annotation?
@@ -47,7 +47,7 @@ What if x is the same type as 10? What if it's a different type? (e.g. a u8)"""
 
 [[exercises]]
 name = "variables3"
-path = "solutions/variables/variables3.cairo"
+path = "exercises/variables/variables3.cairo"
 mode = "compile"
 hint = """
 Oops! In this exercise, we have a variable binding that we've created on
@@ -58,7 +58,7 @@ programming language -- thankfully the Cairo compiler has caught this for us!"""
 
 [[exercises]]
 name = "variables4"
-path = "solutions/variables/variables4.cairo"
+path = "exercises/variables/variables4.cairo"
 mode = "compile"
 hint = """
 In Cairo, variable bindings are immutable by default. But here we're trying
@@ -67,7 +67,7 @@ a variable binding mutable instead."""
 
 [[exercises]]
 name = "variables5"
-path = "solutions/variables/variables5.cairo"
+path = "exercises/variables/variables5.cairo"
 mode = "compile"
 hint = """
 In variables4 we already learned how to make an immutable variable mutable
@@ -84,7 +84,7 @@ Try to solve this exercise afterwards using this technique."""
 
 [[exercises]]
 name = "variables6"
-path = "solutions/variables/variables6.cairo"
+path = "exercises/variables/variables6.cairo"
 mode = "compile"
 hint = """
 We know about variables and mutability, but there is another important type of
@@ -101,7 +101,7 @@ You can read about the different integer types here: https://link.medium.com/c8T
 
 [[exercises]]
 name = "functions1"
-path = "solutions/functions/functions1.cairo"
+path = "exercises/functions/functions1.cairo"
 mode = "compile"
 hint = """
 This main function is calling a function that it expects to exist, but the
@@ -111,7 +111,7 @@ Sounds a lot like `main`, doesn't it?"""
 
 [[exercises]]
 name = "functions2"
-path = "solutions/functions/functions2.cairo"
+path = "exercises/functions/functions2.cairo"
 mode = "compile"
 hint = """
 Cairo requires that all parts of a function's signature have type annotations,
@@ -119,7 +119,7 @@ but `call_me` is missing the type annotation of `num`. What is the basic type in
 
 [[exercises]]
 name = "functions3"
-path = "solutions/functions/functions3.cairo"
+path = "exercises/functions/functions3.cairo"
 mode = "compile"
 hint = """
 This time, the function *declaration* is okay, but there's something wrong
@@ -131,7 +131,7 @@ Watch mode will only jump to the next exercise if you remove the I AM NOT DONE c
 
 [[exercises]]
 name = "functions5"
-path = "solutions/functions/functions4.cairo"
+path = "exercises/functions/functions4.cairo"
 mode = "compile"
 hint = """
 This is a really common error that can be fixed by removing one character.
@@ -143,7 +143,7 @@ They are not the same. There are two solutions:
 
 [[exercises]]
 name = "arrays1"
-path = "solutions/arrays/arrays1.cairo"
+path = "exercises/arrays/arrays1.cairo"
 mode = "test"
 hint = """
 You can declare an array in Cairo using the following syntax:
@@ -156,7 +156,7 @@ The `pop_front` method removes the first element from the array and returns an O
 
 [[exercises]]
 name = "arrays2"
-path = "solutions/arrays/arrays2.cairo"
+path = "exercises/arrays/arrays2.cairo"
 mode = "test"
 hint = """
 How can you remove the first element from the array?
@@ -166,7 +166,7 @@ This will prevent the `Variable not dropped` error.
 
 [[exercises]]
 name = "arrays3"
-path = "solutions/arrays/arrays3.cairo"
+path = "exercises/arrays/arrays3.cairo"
 mode = "test"
 hint = """
 The test fails because you are trying to access an element that is out of bounds!
@@ -178,19 +178,19 @@ Without changing the index accessed, how can we make the test pass? Is there a m
 
 [[exercises]]
 name = "primitive_types1"
-path = "solutions/primitive_types/primitive_types1.cairo"
+path = "exercises/primitive_types/primitive_types1.cairo"
 mode = "compile"
 hint = "No hints this time ;)"
 
 [[exercises]]
 name = "primitive_types2"
-path = "solutions/primitive_types/primitive_types2.cairo"
+path = "exercises/primitive_types/primitive_types2.cairo"
 mode = "compile"
 hint = "No hints this time ;)"
 
 [[exercises]]
 name = "primitive_types3"
-path = "solutions/primitive_types/primitive_types3.cairo"
+path = "exercises/primitive_types/primitive_types3.cairo"
 mode = "compile"
 hint = """
 You'll need to make a pattern to bind `name` and `age` to the appropriate parts
@@ -201,7 +201,7 @@ You can do it!!
 
 [[exercises]]
 name = "primitive_types4"
-path = "solutions/primitive_types/primitive_types4.cairo"
+path = "exercises/primitive_types/primitive_types4.cairo"
 mode = "test"
 hint = """
 There are multiple integer types in Cairo. You can read about them here: https://link.medium.com/c8TqX7R3qxb#6d64
@@ -216,7 +216,7 @@ Take a look at the top of the file to see how these traits are imported.
 
 [[exercises]]
 name = "if1"
-path = "solutions/if/if1.cairo"
+path = "exercises/if/if1.cairo"
 mode = "test"
 hint = """
 Remember in Cairo that:
@@ -226,7 +226,7 @@ Remember in Cairo that:
 
 [[exercises]]
 name = "if2"
-path = "solutions/if/if2.cairo"
+path = "exercises/if/if2.cairo"
 mode = "test"
 hint = """
 For that first compiler error, it's important in Cairo that each conditional
@@ -237,7 +237,7 @@ conditions checking different input values."""
 
 [[exercises]]
 name = "structs1"
-path = "solutions/structs/structs1.cairo"
+path = "exercises/structs/structs1.cairo"
 mode = "test"
 hint = """
 Cairo has a single type of struct that are named collections of related data stored in fields.
@@ -260,7 +260,7 @@ Read more about structs in the Structs section of this article: https://link.med
 
 [[exercises]]
 name = "structs2"
-path = "solutions/structs/structs2.cairo"
+path = "exercises/structs/structs2.cairo"
 mode = "test"
 hint = """
 Cairo requires you to initialize all fields when creating a struct and there is no update syntax available at the moment.
@@ -275,7 +275,7 @@ Read more about structs in the Structs section of this article: https://link.med
 
 [[exercises]]
 name = "structs3"
-path = "solutions/structs/structs3.cairo"
+path = "exercises/structs/structs3.cairo"
 mode = "test"
 hint = """
 For is_international: What makes a package international? Seems related to the places it goes through right?

--- a/info.toml
+++ b/info.toml
@@ -2,25 +2,25 @@
 
 [[exercises]]
 name = "intro1"
-path = "exercises/intro/intro1.cairo"
+path = "solutions/intro/intro1.cairo"
 mode = "compile"
 hint = """"""
 
 [[exercises]]
 name = "intro2"
-path = "exercises/intro/intro2.cairo"
+path = "solutions/intro/intro2.cairo"
 mode = "compile"
 hint = """"""
 
 [[exercises]]
 name = "intro3"
-path = "exercises/intro/intro3.cairo"
+path = "solutions/intro/intro3.cairo"
 mode = "compile"
 hint = """"""
 
 [[exercises]]
 name = "intro4"
-path = "exercises/intro/intro4.cairo"
+path = "solutions/intro/intro4.cairo"
 mode = "compile"
 hint = """"""
 
@@ -28,7 +28,7 @@ hint = """"""
 
 [[exercises]]
 name = "variables1"
-path = "exercises/variables/variables1.cairo"
+path = "solutions/variables/variables1.cairo"
 mode = "compile"
 hint = """
 The declaration on line 8 is missing a keyword that is needed in Cairo
@@ -36,7 +36,7 @@ to create a new variable binding."""
 
 [[exercises]]
 name = "variables2"
-path = "exercises/variables/variables2.cairo"
+path = "solutions/variables/variables2.cairo"
 mode = "compile"
 hint = """
 What happens if you annotate line 7 with a type annotation?
@@ -47,7 +47,7 @@ What if x is the same type as 10? What if it's a different type? (e.g. a u8)"""
 
 [[exercises]]
 name = "variables3"
-path = "exercises/variables/variables3.cairo"
+path = "solutions/variables/variables3.cairo"
 mode = "compile"
 hint = """
 Oops! In this exercise, we have a variable binding that we've created on
@@ -58,7 +58,7 @@ programming language -- thankfully the Cairo compiler has caught this for us!"""
 
 [[exercises]]
 name = "variables4"
-path = "exercises/variables/variables4.cairo"
+path = "solutions/variables/variables4.cairo"
 mode = "compile"
 hint = """
 In Cairo, variable bindings are immutable by default. But here we're trying
@@ -67,7 +67,7 @@ a variable binding mutable instead."""
 
 [[exercises]]
 name = "variables5"
-path = "exercises/variables/variables5.cairo"
+path = "solutions/variables/variables5.cairo"
 mode = "compile"
 hint = """
 In variables4 we already learned how to make an immutable variable mutable
@@ -84,7 +84,7 @@ Try to solve this exercise afterwards using this technique."""
 
 [[exercises]]
 name = "variables6"
-path = "exercises/variables/variables6.cairo"
+path = "solutions/variables/variables6.cairo"
 mode = "compile"
 hint = """
 We know about variables and mutability, but there is another important type of
@@ -101,7 +101,7 @@ You can read about the different integer types here: https://link.medium.com/c8T
 
 [[exercises]]
 name = "functions1"
-path = "exercises/functions/functions1.cairo"
+path = "solutions/functions/functions1.cairo"
 mode = "compile"
 hint = """
 This main function is calling a function that it expects to exist, but the
@@ -111,7 +111,7 @@ Sounds a lot like `main`, doesn't it?"""
 
 [[exercises]]
 name = "functions2"
-path = "exercises/functions/functions2.cairo"
+path = "solutions/functions/functions2.cairo"
 mode = "compile"
 hint = """
 Cairo requires that all parts of a function's signature have type annotations,
@@ -119,7 +119,7 @@ but `call_me` is missing the type annotation of `num`. What is the basic type in
 
 [[exercises]]
 name = "functions3"
-path = "exercises/functions/functions3.cairo"
+path = "solutions/functions/functions3.cairo"
 mode = "compile"
 hint = """
 This time, the function *declaration* is okay, but there's something wrong
@@ -131,7 +131,7 @@ Watch mode will only jump to the next exercise if you remove the I AM NOT DONE c
 
 [[exercises]]
 name = "functions5"
-path = "exercises/functions/functions4.cairo"
+path = "solutions/functions/functions4.cairo"
 mode = "compile"
 hint = """
 This is a really common error that can be fixed by removing one character.
@@ -143,7 +143,7 @@ They are not the same. There are two solutions:
 
 [[exercises]]
 name = "arrays1"
-path = "exercises/arrays/arrays1.cairo"
+path = "solutions/arrays/arrays1.cairo"
 mode = "test"
 hint = """
 You can declare an array in Cairo using the following syntax:
@@ -156,7 +156,7 @@ The `pop_front` method removes the first element from the array and returns an O
 
 [[exercises]]
 name = "arrays2"
-path = "exercises/arrays/arrays2.cairo"
+path = "solutions/arrays/arrays2.cairo"
 mode = "test"
 hint = """
 How can you remove the first element from the array?
@@ -166,10 +166,10 @@ This will prevent the `Variable not dropped` error.
 
 [[exercises]]
 name = "arrays3"
-path = "exercises/arrays/arrays3.cairo"
+path = "solutions/arrays/arrays3.cairo"
 mode = "test"
 hint = """
-The test fails because you are trying to access an element that is out of bounds! 
+The test fails because you are trying to access an element that is out of bounds!
 By using array.pop_front(), we remove the first element from the array, so the index of the last element is no longer 2.
 Without changing the index accessed, how can we make the test pass? Is there a method that returns an option that could help us?
 """
@@ -178,19 +178,19 @@ Without changing the index accessed, how can we make the test pass? Is there a m
 
 [[exercises]]
 name = "primitive_types1"
-path = "exercises/primitive_types/primitive_types1.cairo"
+path = "solutions/primitive_types/primitive_types1.cairo"
 mode = "compile"
 hint = "No hints this time ;)"
 
 [[exercises]]
 name = "primitive_types2"
-path = "exercises/primitive_types/primitive_types2.cairo"
+path = "solutions/primitive_types/primitive_types2.cairo"
 mode = "compile"
 hint = "No hints this time ;)"
 
 [[exercises]]
 name = "primitive_types3"
-path = "exercises/primitive_types/primitive_types3.cairo"
+path = "solutions/primitive_types/primitive_types3.cairo"
 mode = "compile"
 hint = """
 You'll need to make a pattern to bind `name` and `age` to the appropriate parts
@@ -201,7 +201,7 @@ You can do it!!
 
 [[exercises]]
 name = "primitive_types4"
-path = "exercises/primitive_types/primitive_types4.cairo"
+path = "solutions/primitive_types/primitive_types4.cairo"
 mode = "test"
 hint = """
 There are multiple integer types in Cairo. You can read about them here: https://link.medium.com/c8TqX7R3qxb#6d64
@@ -216,7 +216,7 @@ Take a look at the top of the file to see how these traits are imported.
 
 [[exercises]]
 name = "if1"
-path = "exercises/if/if1.cairo"
+path = "solutions/if/if1.cairo"
 mode = "test"
 hint = """
 Remember in Cairo that:
@@ -226,7 +226,7 @@ Remember in Cairo that:
 
 [[exercises]]
 name = "if2"
-path = "exercises/if/if2.cairo"
+path = "solutions/if/if2.cairo"
 mode = "test"
 hint = """
 For that first compiler error, it's important in Cairo that each conditional
@@ -237,7 +237,7 @@ conditions checking different input values."""
 
 [[exercises]]
 name = "structs1"
-path = "exercises/structs/structs1.cairo"
+path = "solutions/structs/structs1.cairo"
 mode = "test"
 hint = """
 Cairo has a single type of struct that are named collections of related data stored in fields.
@@ -260,7 +260,7 @@ Read more about structs in the Structs section of this article: https://link.med
 
 [[exercises]]
 name = "structs2"
-path = "exercises/structs/structs2.cairo"
+path = "solutions/structs/structs2.cairo"
 mode = "test"
 hint = """
 Cairo requires you to initialize all fields when creating a struct and there is no update syntax available at the moment.
@@ -275,7 +275,7 @@ Read more about structs in the Structs section of this article: https://link.med
 
 [[exercises]]
 name = "structs3"
-path = "exercises/structs/structs3.cairo"
+path = "solutions/structs/structs3.cairo"
 mode = "test"
 hint = """
 For is_international: What makes a package international? Seems related to the places it goes through right?

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -52,11 +52,3 @@ thiserror = "1.0.32"
 assert_cmd = "0.11.0"
 predicates = "1.0.1"
 glob = "0.3.0"
-
-[[bin]]
-name = "starklings"
-path = "main.rs"
-
-[[bin]]
-name = "cairo-runner"
-path = "cairo-runner.rs"

--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -90,16 +90,14 @@ impl Drop for FileHandle {
 
 impl Exercise {
     pub fn run_cairo(&self) -> std::process::Output {
-        let cmd = Command::new("cargo")
-            .args(&["run", "-q", "--bin", "cairo-runner", "--"])
+        let cmd = Command::new("target/release/cairo-runner")
             .args(&["--path", self.path.to_str().unwrap()])
             .output();
         cmd.expect("Failed to run 'compile' command.")
     }
 
     pub fn test_cairo(&self) -> std::process::Output {
-        let cmd = Command::new("cargo")
-            .args(&["run", "-q", "--bin", "cairo-tester", "--"])
+        let cmd = Command::new("target/release/cairo-tester")
             .args(&["--path", self.path.to_str().unwrap()])
             .output();
         cmd.expect("Failed to run 'test' command.")

--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -90,14 +90,18 @@ impl Drop for FileHandle {
 
 impl Exercise {
     pub fn run_cairo(&self) -> std::process::Output {
-        let cmd = Command::new("target/release/cairo-runner")
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("target/debug/cairo-runner");
+        let cmd = Command::new(path)
             .args(&["--path", self.path.to_str().unwrap()])
             .output();
         cmd.expect("Failed to run 'compile' command.")
     }
 
     pub fn test_cairo(&self) -> std::process::Output {
-        let cmd = Command::new("target/release/cairo-tester")
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("target/debug/cairo-tester");
+        let cmd = Command::new(path)
             .args(&["--path", self.path.to_str().unwrap()])
             .output();
         cmd.expect("Failed to run 'test' command.")

--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -5,7 +5,9 @@ use std::fmt::{self, Display, Formatter};
 use std::fs::{remove_file, File};
 use std::io::Read;
 use std::path::PathBuf;
-use std::process::{self, Command};
+use std::process::{self};
+use crate::starklings_runner::{Args as RunnerArgs,run_cairo_program};
+use crate::starklings_tester::{Args as TesterArgs ,test_cairo_program};
 
 const I_AM_DONE_REGEX: &str = r"(?m)^\s*///?\s*I\s+AM\s+NOT\s+DONE";
 const CONTEXT: usize = 2;
@@ -89,22 +91,23 @@ impl Drop for FileHandle {
 }
 
 impl Exercise {
-    pub fn run_cairo(&self) -> std::process::Output {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("target/debug/cairo-runner");
-        let cmd = Command::new(path)
-            .args(&["--path", self.path.to_str().unwrap()])
-            .output();
-        cmd.expect("Failed to run 'compile' command.")
+    pub fn run_cairo(&self) -> anyhow::Result<String> {
+        run_cairo_program(&RunnerArgs{
+            path: self.path.to_str().unwrap().parse()?,
+            available_gas: None,
+            print_full_memory: false,
+        })
+
     }
 
-    pub fn test_cairo(&self) -> std::process::Output {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("target/debug/cairo-tester");
-        let cmd = Command::new(path)
-            .args(&["--path", self.path.to_str().unwrap()])
-            .output();
-        cmd.expect("Failed to run 'test' command.")
+    pub fn test_cairo(&self) -> anyhow::Result<String> {
+        test_cairo_program(&TesterArgs{
+            path: self.path.to_str().unwrap().parse()?,
+            filter: "".to_string(),
+            include_ignored: false,
+            ignored: false,
+            starknet: false,
+        })
     }
 
     pub fn state(&self) -> State {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,12 @@ use std::time::Duration;
 
 #[macro_use]
 mod ui;
-
 mod exercise;
 mod project;
 mod run;
 mod verify;
+mod starklings_tester;
+mod starklings_runner;
 
 // In sync with crate version
 const VERSION: &str = "5.3.0";

--- a/src/run.rs
+++ b/src/run.rs
@@ -37,16 +37,17 @@ fn run_cairo(exercise: &Exercise) -> Result<(), ()> {
     progress_bar.enable_steady_tick(100);
     let output = exercise.run_cairo();
 
-    if output.stderr.len() > 0 {
+    if let Some(error) = output.as_ref().err(){
         progress_bar.finish_and_clear();
         println!("Err");
-        println!("{}", String::from_utf8(output.stderr).unwrap());
+        println!("{}", error.to_string());
 
         println!("Normal");
-        println!("{}", String::from_utf8(output.stdout).unwrap());
+        println!("{}", error.to_string());
         Err(())
     } else {
-        println!("{}", String::from_utf8(output.stdout).unwrap());
+        let message = output.unwrap();
+        println!("{}", message);
         success!("Successfully ran {}", exercise);
         Ok(())
     }
@@ -61,16 +62,17 @@ fn test_cairo(exercise: &Exercise) -> Result<(), ()> {
     progress_bar.enable_steady_tick(100);
     let output = exercise.test_cairo();
 
-    if output.stderr.len() > 0 {
+    if let Some(error) = output.as_ref().err(){
         progress_bar.finish_and_clear();
         println!("Err");
-        println!("{}", String::from_utf8(output.stderr).unwrap());
+        println!("{}", error.to_string());
 
         println!("Normal");
-        println!("{}", String::from_utf8(output.stdout).unwrap());
+        println!("{}", error.to_string());
         Err(())
     } else {
-        println!("{}", String::from_utf8(output.stdout).unwrap());
+        let message = output.unwrap();
+        println!("{}", message);
         success!("Successfully ran {}", exercise);
         Ok(())
     }

--- a/src/starklings_tester.rs
+++ b/src/starklings_tester.rs
@@ -39,22 +39,22 @@ const CORELIB_DIR_NAME: &str = "corelib";
 /// Exits with 0/1 if the input is formatted correctly/incorrectly.
 #[derive(Parser, Debug)]
 #[clap(version, verbatim_doc_comment)]
-struct Args {
+pub struct Args {
     /// The path to compile and run its tests.
     #[arg(short, long)]
-    path: String,
+    pub path: String,
     /// The filter for the tests, running only tests containing the filter string.
     #[arg(short, long, default_value_t = String::default())]
-    filter: String,
+    pub filter: String,
     /// Should we run ignored tests as well.
     #[arg(long, default_value_t = false)]
-    include_ignored: bool,
+    pub include_ignored: bool,
     /// Should we run only the ignored tests.
     #[arg(long, default_value_t = false)]
-    ignored: bool,
+    pub ignored: bool,
     /// Should we add the starknet plugin to run the tests.
     #[arg(long, default_value_t = false)]
-    starknet: bool,
+    pub starknet: bool,
 }
 
 /// The status of a ran test.
@@ -66,8 +66,16 @@ enum TestStatus {
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+    let res = test_cairo_program(&args);
+    if let Err(e) = res {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+    Ok(())
+}
 
-    // TODO(orizi): Use `get_default_plugins` and just update the config plugin.
+pub fn test_cairo_program(args: &Args) -> anyhow::Result<String> {
+// TODO(orizi): Use `get_default_plugins` and just update the config plugin.
     let mut plugins: Vec<Arc<dyn SemanticPlugin>> = vec![
         Arc::new(DerivePlugin {}),
         Arc::new(PanicablePlugin {}),
@@ -115,7 +123,7 @@ fn main() -> anyhow::Result<()> {
                     FunctionLongId {
                         function: ConcreteFunction {
                             generic_function: GenericFunctionId::Free(test.func_id),
-                            generic_args: vec![]
+                            generic_args: vec![],
                         }
                     }
                         .debug(db)
@@ -139,7 +147,7 @@ fn main() -> anyhow::Result<()> {
             failed.len(),
             ignored.len()
         ).as_str());
-        Ok(())
+        Ok(result_string)
     } else {
         result_string.push_str(format!("failures:").as_str());
         for (failure, run_result) in failed.iter().zip_eq(failed_run_results) {
@@ -169,7 +177,7 @@ fn main() -> anyhow::Result<()> {
             passed.len(),
             failed.len(),
             ignored.len()
-        );
+        )
     }
 }
 
@@ -237,7 +245,7 @@ fn run_tests(
                 }
                 TestStatus::Ignore => (&mut summary.ignored, "ignored".bright_yellow()),
             };
-            println!("test {name} ... {status_str}",);
+            println!("test {name} ... {status_str}", );
             res_type.push(name);
         });
     wrapped_summary.into_inner().unwrap()

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -101,7 +101,7 @@ fn compile_and_test_cairo<'a, 'b>(
     if let Some(error) = compilation_result.as_ref().err() {
         progress_bar.finish_and_clear();
         warn!(
-            "Compiling of {} failed! Please try again. Here's the output:",
+            "Testing of {} failed! Please try again. Here's the output:",
             exercise
         );
         println!("{}", error.to_string());

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -48,7 +48,7 @@ fn compile_and_run_interactively(exercise: &Exercise) -> Result<bool, ()> {
 
     Ok(prompt_for_completion(
         exercise,
-        Some(String::from_utf8(run_state.stdout).unwrap()),
+        Some(run_state)
     ))
 }
 
@@ -65,7 +65,7 @@ fn compile_and_test_interactively(exercise: &Exercise) -> Result<bool, ()> {
 
     Ok(prompt_for_completion(
         exercise,
-        Some(String::from_utf8(run_state.stdout).unwrap()),
+        Some(run_state),
     ))
 }
 
@@ -74,19 +74,19 @@ fn compile_and_test_interactively(exercise: &Exercise) -> Result<bool, ()> {
 fn compile_and_run_cairo<'a, 'b>(
     exercise: &'a Exercise,
     progress_bar: &'b ProgressBar,
-) -> Result<std::process::Output, ()> {
+) -> Result<String, ()> {
     let compilation_result = exercise.run_cairo();
 
-    if compilation_result.stderr.len() > 0 {
+    if let Some(error) = compilation_result.as_ref().err() {
         progress_bar.finish_and_clear();
         warn!(
             "Compiling of {} failed! Please try again. Here's the output:",
             exercise
         );
-        println!("{}", String::from_utf8(compilation_result.stderr).unwrap());
+        println!("{}", error.to_string());
         Err(())
     } else {
-        Ok(compilation_result)
+        Ok(compilation_result.unwrap())
     }
 }
 
@@ -95,19 +95,19 @@ fn compile_and_run_cairo<'a, 'b>(
 fn compile_and_test_cairo<'a, 'b>(
     exercise: &'a Exercise,
     progress_bar: &'b ProgressBar,
-) -> Result<std::process::Output, ()> {
+) -> Result<String, ()> {
     let compilation_result = exercise.test_cairo();
 
-    if compilation_result.stderr.len() > 0 {
+    if let Some(error) = compilation_result.as_ref().err() {
         progress_bar.finish_and_clear();
         warn!(
-            "Test of {} failed! Please try again. Here's the output:",
+            "Compiling of {} failed! Please try again. Here's the output:",
             exercise
         );
-        println!("{}", String::from_utf8(compilation_result.stderr).unwrap());
+        println!("{}", error.to_string());
         Err(())
     } else {
-        Ok(compilation_result)
+        Ok(compilation_result.unwrap())
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 use assert_cmd::prelude::*;
 use glob::glob;
-use predicates::boolean::PredicateBooleanExt;
+
 use std::fs::File;
 use std::io::Read;
 use std::process::Command;


### PR DESCRIPTION
Fixes #25 
The user will need to build the binaries before using starklings with `cargo build --all`.
We invoke directly the executables in starklings instead of using cargo, which speeds things up _at least_ 10x.

Time spent: 3 hours