### PR TITLE
refactor: exercises order

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -95,87 +95,6 @@ Constants types must also always be annotated.
 You can read about the different integer types here: https://link.medium.com/c8TqX7R3qxb#6d64
 """
 
-
-
-# FUNCTIONS
-
-[[exercises]]
-name = "functions1"
-path = "exercises/functions/functions1.cairo"
-mode = "compile"
-hint = """
-This main function is calling a function that it expects to exist, but the
-function doesn't exist. It expects this function to have the name `call_me`.
-It expects this function to not take any arguments and not return a value.
-Sounds a lot like `main`, doesn't it?"""
-
-[[exercises]]
-name = "functions2"
-path = "exercises/functions/functions2.cairo"
-mode = "compile"
-hint = """
-Cairo requires that all parts of a function's signature have type annotations,
-but `call_me` is missing the type annotation of `num`. What is the basic type in Cairo?"""
-
-[[exercises]]
-name = "functions3"
-path = "exercises/functions/functions3.cairo"
-mode = "compile"
-hint = """
-This time, the function *declaration* is okay, but there's something wrong
-with the place where we're calling the function.
-Remember how we can use a suffix to specify the type of a literal? https://link.medium.com/c8TqX7R3qxb#6d64
-As a reminder, you can freely play around with different solutions in Starklings!
-Watch mode will only jump to the next exercise if you remove the I AM NOT DONE comment."""
-
-
-[[exercises]]
-name = "functions5"
-path = "exercises/functions/functions4.cairo"
-mode = "compile"
-hint = """
-This is a really common error that can be fixed by removing one character.
-It happens because Cairo distinguishes between expressions and statements: expressions return a value based on their operand(s), and statements simply return a () type which behaves just like `void` in C/C++ language.
-We want to return a value of `felt` type from the `square` function, but it is returning a `()` type...
-They are not the same. There are two solutions:
-1. Add a `return` ahead of `num * num;`
-2. remove `;`, make it to be `num * num`"""
-
-# Arrays
-
-[[exercises]]
-name = "arrays1"
-path = "exercises/arrays/arrays1.cairo"
-mode = "test"
-hint = """
-You can declare an array in Cairo using the following syntax:
-`let your_array = ArrayTrait::new();`
-You can append elements to an array using the following syntax:
-`your_array.append(element);`
-
-The `pop_front` method removes the first element from the array and returns an Option::Some(value) if the array is not empty, or Option::None() if the array is empty.
-"""
-
-[[exercises]]
-name = "arrays2"
-path = "exercises/arrays/arrays2.cairo"
-mode = "test"
-hint = """
-How can you remove the first element from the array?
-Take a look at the previous exercise for a hint. Don't forget to call `.unwrap()` on the returned value.
-This will prevent the `Variable not dropped` error.
-"""
-
-[[exercises]]
-name = "arrays3"
-path = "exercises/arrays/arrays3.cairo"
-mode = "test"
-hint = """
-The test fails because you are trying to access an element that is out of bounds!
-By using array.pop_front(), we remove the first element from the array, so the index of the last element is no longer 2.
-Without changing the index accessed, how can we make the test pass? Is there a method that returns an option that could help us?
-"""
-
 # PRIMITIVE TYPES
 
 [[exercises]]
@@ -228,12 +147,6 @@ path = "exercises/operations/operations2.cairo"
 mode = "test"
 hint = """Use % for modulus, / for division, and * for multiplication."""
 
-[[exercises]]
-name = "quizs1"
-path = "exercises/quizs/quizs1.cairo"
-mode = "test"
-hint = """No hints this time ;)"""
-
 # IF
 
 [[exercises]]
@@ -254,6 +167,150 @@ hint = """
 For that first compiler error, it's important in Cairo that each conditional
 block returns the same type! To get the tests passing, you will need a couple
 conditions checking different input values."""
+
+# FUNCTIONS
+
+[[exercises]]
+name = "functions1"
+path = "exercises/functions/functions1.cairo"
+mode = "compile"
+hint = """
+This main function is calling a function that it expects to exist, but the
+function doesn't exist. It expects this function to have the name `call_me`.
+It expects this function to not take any arguments and not return a value.
+Sounds a lot like `main`, doesn't it?"""
+
+[[exercises]]
+name = "functions2"
+path = "exercises/functions/functions2.cairo"
+mode = "compile"
+hint = """
+Cairo requires that all parts of a function's signature have type annotations,
+but `call_me` is missing the type annotation of `num`. What is the basic type in Cairo?"""
+
+[[exercises]]
+name = "functions3"
+path = "exercises/functions/functions3.cairo"
+mode = "compile"
+hint = """
+This time, the function *declaration* is okay, but there's something wrong
+with the place where we're calling the function.
+Remember how we can use a suffix to specify the type of a literal? https://link.medium.com/c8TqX7R3qxb#6d64
+As a reminder, you can freely play around with different solutions in Starklings!
+Watch mode will only jump to the next exercise if you remove the I AM NOT DONE comment."""
+
+
+[[exercises]]
+name = "functions4"
+path = "exercises/functions/functions4.cairo"
+mode = "compile"
+hint = """
+This is a really common error that can be fixed by removing one character.
+It happens because Cairo distinguishes between expressions and statements: expressions return a value based on their operand(s), and statements simply return a () type which behaves just like `void` in C/C++ language.
+We want to return a value of `felt` type from the `square` function, but it is returning a `()` type...
+They are not the same. There are two solutions:
+1. Add a `return` ahead of `num * num;`
+2. remove `;`, make it to be `num * num`"""
+
+# QUIZ 1
+
+[[exercises]]
+name = "quizs1"
+path = "exercises/quizs/quizs1.cairo"
+mode = "test"
+hint = """No hints this time ;)"""
+
+# ENUMS
+
+[[exercises]]
+name = "enums1"
+path = "exercises/enums/enums1.cairo"
+mode = "compile"
+hint = "No hints this time ;)"
+
+[[exercises]]
+name = "enums2"
+path = "exercises/enums/enums2.cairo"
+mode = "compile"
+hint = """
+You can create enumerations that have different variants with different types
+such as no data, structs, a single felt string, tuples, ...etc"""
+
+[[exercises]]
+name = "enums3"
+path = "exercises/enums/enums3.cairo"
+mode = "test"
+hint = """
+As a first step, you can define enums to compile this code without errors.
+and then create a match expression in `process()`.
+Note that you need to deconstruct some message variants
+in the match expression to get value in the variant.
+"""
+
+# OPTIONS
+
+[[exercises]]
+name = "options1"
+path = "exercises/options/options1.cairo"
+mode = "test"
+hint = """
+Options can have a Some value, with an inner value, or a None value, without an inner value.
+There's multiple ways to get at the inner value, you can use unwrap, or pattern match. Unwrapping
+is the easiest, but how do you do it safely so that it doesn't panic in your face later?"""
+
+[[exercises]]
+name = "options2"
+path = "exercises/options/options2.cairo"
+mode = "test"
+hint = """
+check out: https://github.com/starkware-libs/cairo/blob/main/corelib/src/option.cairo
+to see the implementation of the Option type and its methods.
+"""
+
+[[exercises]]
+name = "options3"
+path = "exercises/options/options3.cairo"
+mode = "test"
+hint = """
+Reminder: You can use a match statement with an Option to handle both the Some and None cases.
+This syntax is more flexible than using unwrap, which only handles the Some case, and contributes to more robust code.
+"""
+
+# Arrays
+
+[[exercises]]
+name = "arrays1"
+path = "exercises/arrays/arrays1.cairo"
+mode = "test"
+hint = """
+You can declare an array in Cairo using the following syntax:
+`let your_array = ArrayTrait::new();`
+You can append elements to an array using the following syntax:
+`your_array.append(element);`
+
+The `pop_front` method removes the first element from the array and returns an Option::Some(value) if the array is not empty, or Option::None() if the array is empty.
+"""
+
+[[exercises]]
+name = "arrays2"
+path = "exercises/arrays/arrays2.cairo"
+mode = "test"
+hint = """
+How can you remove the first element from the array?
+Take a look at the previous exercise for a hint. Don't forget to call `.unwrap()` on the returned value.
+This will prevent the `Variable not dropped` error.
+"""
+
+[[exercises]]
+name = "arrays3"
+path = "exercises/arrays/arrays3.cairo"
+mode = "test"
+hint = """
+The test fails because you are trying to access an element that is out of bounds!
+By using array.pop_front(), we remove the first element from the array, so the index of the last element is no longer 2.
+Without changing the index accessed, how can we make the test pass? Is there a method that returns an option that could help us?
+"""
+
 
 # STRUCTS
 
@@ -308,61 +365,6 @@ Looking at the test functions will also help you understand more about the synta
 This section will help you understanding more about impls and traits: https://link.medium.com/c8TqX7R3qxb#83b5.
 """
 
-# ENUMS
-
-[[exercises]]
-name = "enums1"
-path = "exercises/enums/enums1.cairo"
-mode = "compile"
-hint = "No hints this time ;)"
-
-[[exercises]]
-name = "enums2"
-path = "exercises/enums/enums2.cairo"
-mode = "compile"
-hint = """
-You can create enumerations that have different variants with different types
-such as no data, structs, a single felt string, tuples, ...etc"""
-
-[[exercises]]
-name = "enums3"
-path = "exercises/enums/enums3.cairo"
-mode = "test"
-hint = """
-As a first step, you can define enums to compile this code without errors.
-and then create a match expression in `process()`. 
-Note that you need to deconstruct some message variants 
-in the match expression to get value in the variant.
-"""
-
-# OPTIONS
-
-[[exercises]]
-name = "options1"
-path = "exercises/options/options1.cairo"
-mode = "test"
-hint = """
-Options can have a Some value, with an inner value, or a None value, without an inner value.
-There's multiple ways to get at the inner value, you can use unwrap, or pattern match. Unwrapping
-is the easiest, but how do you do it safely so that it doesn't panic in your face later?"""
-
-[[exercises]]
-name = "options2"
-path = "exercises/options/options2.cairo"
-mode = "test"
-hint = """
-check out: https://github.com/starkware-libs/cairo/blob/main/corelib/src/option.cairo 
-to see the implementation of the Option type and its methods.
-"""
-
-[[exercises]]
-name = "options3"
-path = "exercises/options/options3.cairo"
-mode = "test"
-hint = """
-Reminder: You can use a match statement with an Option to handle both the Some and None cases.
-This syntax is more flexible than using unwrap, which only handles the Some case, and contributes to more robust code.
-"""
 
 # MOVE SEMANTICS
 


### PR DESCRIPTION
Changes the order of the exercises for a more natural and sequential approach to the language. This ensures that every concept used in the exercises has been seen before.