### PR TITLE
Fix links in array README

### DIFF
--- a/exercises/arrays/README.md
+++ b/exercises/arrays/README.md
@@ -7,6 +7,6 @@ This has to do with the fact that once a memory slot is written to, it cannot be
 
 ## Further information
 
-- [Arrays](https://link.medium.com/MeQ1Agthrxb#570c]
-- [Core library](https://github.com/starkware-libs/cairo/blob/main/corelib/array.cairo)
+- [Arrays](https://link.medium.com/MeQ1Agthrxb#570c)
+- [Core library](https://github.com/starkware-libs/cairo/blob/main/corelib/src/array.cairo)
 - [Cairo memory model](https://link.medium.com/o5ZpTQOPuxb#2c01)


### PR DESCRIPTION
- Medium link was malformed
- Updated Core library link as it has moved to `.../src/...`