### PR TITLE
Watch start at

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ With rustup `curl https://sh.rustup.rs -sSf | sh -s`
 2. Run `cargo run --bin starklings`, this might take a while the first time.
 3. You should see this intro message, run `cargo run --bin starklings watch` when you are ready!
 
-## Start at a specific exercise
+## Start at a specific exercise `NEW`
 
 To start watch at a specific exercise pass the name of the exercise to watch command.
 For example, to start at `starknet1`,

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ For example, to start at `starknet1`,
 cargo run --bin starklings watch starknet1
 ```
 
+## Welcome message and instrucitons
+
 ```
 starklings - An interactive tutorial to get started with Cairo and Starknet
 
@@ -63,12 +65,12 @@ Here's how starklings works,
 error message popping up as soon as you run starklings! This is part of the
 exercise that you're supposed to solve, so open the exercise file in an editor
 and start your detective work!
-1. If you're stuck on an exercise, there is a helpful hint you can view by
+3. If you're stuck on an exercise, there is a helpful hint you can view by
 typing `hint` (in watch mode), or running `cargo run --bin starklings hint
 exercise_name`.
-1. When you have solved the exercise successfully, Remove `// I AM NOT DONE`
+4. When you have solved the exercise successfully, Remove `// I AM NOT DONE`
 comment to move on to the next exercise.
-1. If an exercise doesn't make sense to you, please open an issue on GitHub!
+5. If an exercise doesn't make sense to you, please open an issue on GitHub!
 (https://github.com/shramee/starklings-cairo1/issues/new).
 
 Got all that? Great! To get started, run `starklings watch` in order to get the

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ With rustup `curl https://sh.rustup.rs -sSf | sh -s`
 2. Run `cargo run --bin starklings`, this might take a while the first time.
 3. You should see this intro message, run `cargo run --bin starklings watch` when you are ready!
 
+## Start at a specific exercise
+
+To start watch at a specific exercise pass the name of the exercise to watch command.
+For example, to start at `starknet1`,
+
+```
+cargo run --bin starklings watch starknet1
+```
+
 ```
 starklings - An interactive tutorial to get started with Cairo and Starknet
 
@@ -54,12 +63,12 @@ Here's how starklings works,
 error message popping up as soon as you run starklings! This is part of the
 exercise that you're supposed to solve, so open the exercise file in an editor
 and start your detective work!
-3. If you're stuck on an exercise, there is a helpful hint you can view by
+1. If you're stuck on an exercise, there is a helpful hint you can view by
 typing `hint` (in watch mode), or running `cargo run --bin starklings hint
 exercise_name`.
-4. When you have solved the exercise successfully, Remove `// I AM NOT DONE`
+1. When you have solved the exercise successfully, Remove `// I AM NOT DONE`
 comment to move on to the next exercise.
-5. If an exercise doesn't make sense to you, please open an issue on GitHub!
+1. If an exercise doesn't make sense to you, please open an issue on GitHub!
 (https://github.com/shramee/starklings-cairo1/issues/new).
 
 Got all that? Great! To get started, run `starklings watch` in order to get the

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -40,7 +40,7 @@ fn compile_and_run_interactively(exercise: &Exercise) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.enable_steady_tick(100);
 
-    progress_bar.set_message(format!("Running {exercise}..."));
+    progress_bar.set_message(format!("Running {exercise} exercise..."));
 
     let run_state = compile_and_run_cairo(exercise, &progress_bar)?;
 
@@ -54,7 +54,7 @@ fn compile_and_test_interactively(exercise: &Exercise) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.enable_steady_tick(100);
 
-    progress_bar.set_message(format!("Testing {exercise}..."));
+    progress_bar.set_message(format!("Testing {exercise} exercise..."));
 
     let run_state = compile_and_test_cairo(exercise, &progress_bar)?;
 


### PR DESCRIPTION
## Start at a specific exercise `NEW`

To start watch at a specific exercise pass the name of the exercise to watch command.
For example, to start at `starknet1`,

```
cargo run --bin starklings watch starknet1
```
