### PR TITLE
fix: cairo's language server expect this file to be present else it crashes

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,0 +1,7 @@
+[package]
+name = "starklings_cairo1"
+version = "0.1.0"
+
+# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
+
+[dependencies]


### PR DESCRIPTION
to reproduce the issue:
- open this project in vscode with cairo-lang-language-server setup as mentioned [here](https://github.com/starkware-libs/cairo/blob/main/vscode-cairo/README.md)
- open any cairo file
- see the extension crashing:

![image](https://github.com/shramee/starklings-cairo1/assets/87354252/f765e25b-fd08-4683-bb6f-266bb0e1886f)

Ideally extension shouldn't crash even if `Scarb.toml` file is not present but because this is a cairo 1.0 project having a `Scarb.toml` in root of the repository make sense.