### PR TITLE
fix: add expected file

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,0 +1,7 @@
+[package]
+name = "starklings_cairo1"
+version = "0.1.0"
+
+# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
+
+[dependencies]


### PR DESCRIPTION
due to bug in vscode-cairo extension if scarb is installed it uses scarb's language server which expects this file to be present else it crashes.

see #127