### PR TITLE
Replace chapter 3 for chapter 4 in the broken links

### DIFF
--- a/exercises/move_semantics/README.md
+++ b/exercises/move_semantics/README.md
@@ -4,5 +4,5 @@
 
 For this section, reading the Cairo book references is especially important.
 
-- [Ownership](https://cairo-book.github.io/ch03-00-understanding-ownership.html)
-- [Reference and borrowing](https://cairo-book.github.io/ch03-02-references-and-snapshots.html)
+- [Ownership](https://cairo-book.github.io/ch04-00-understanding-ownership.html)
+- [Reference and borrowing](https://cairo-book.github.io/ch04-02-references-and-snapshots.html)

--- a/info.toml
+++ b/info.toml
@@ -394,7 +394,7 @@ where the error is.
 
 Also: Try accessing `arr0` after having called `fill_arr()`. See what happens!
 
-Read more about move semantics and ownership here: https://cairo-book.github.io/ch03-01-what-is-ownership.html
+Read more about move semantics and ownership here: https://cairo-book.github.io/ch04-01-what-is-ownership.html
 """
 
 [[exercises]]


### PR DESCRIPTION
Hi, It seems like the links to the Cairo Book (understanding-ownership & references-and-snapshots) are broken (the chapter is incorrect). 
