### PR TITLE
Added Missing Hint Message to Starknet3 Exercise

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -547,7 +547,9 @@ No hints this time ;)
 name = "starknet3"
 path = "exercises/starknet/basics/starknet3.cairo"
 mode = "test"
-hint = """ """
+hint = """
+No hints this time ;)
+"""
 
 [[exercises]]
 name = "starknet4"


### PR DESCRIPTION
Starknet3 exercice got no hint, like the 2 previous starknet basics exercices. However for the previous one, the message "No hints this time ;)" was displayed, while nothing is displayed for starknet3 exercice.
