### PR TITLE
Simplified syntax of unit type enums and options

### DIFF
--- a/exercises/enums/enums1.cairo
+++ b/exercises/enums/enums1.cairo
@@ -9,19 +9,19 @@ enum Message { // TODO: define a few types of messages as used below
 }
 
 fn main() {
-    Message::Quit(()).print();
-    Message::Echo(()).print();
-    Message::Move(()).print();
-    Message::ChangeColor(()).print();
+    Message::Quit.print();
+    Message::Echo.print();
+    Message::Move.print();
+    Message::ChangeColor.print();
 }
 
 impl MessagePrintImpl of PrintTrait<Message> {
     fn print(self: Message) {
         match self {
-            Message::Quit(()) => ('Quit').print(),
-            Message::Echo(()) => ('Echo').print(),
-            Message::Move(()) => ('Move').print(),
-            Message::ChangeColor(()) => ('ChangeColor').print()
+            Message::Quit => ('Quit').print(),
+            Message::Echo => ('Echo').print(),
+            Message::Move => ('Move').print(),
+            Message::ChangeColor => ('ChangeColor').print()
         }
     }
 }

--- a/exercises/enums/enums2.cairo
+++ b/exercises/enums/enums2.cairo
@@ -14,7 +14,7 @@ enum Message { // TODO: define the different variants used below
 
 fn main() {
     let mut messages: Array<Message> = ArrayTrait::new();
-    messages.append(Message::Quit(()));
+    messages.append(Message::Quit);
     messages.append(Message::Echo('hello world'));
     messages.append(Message::Move((10, 30)));
     messages.append(Message::ChangeColor((0, 255, 255)));
@@ -37,7 +37,7 @@ impl MessageImpl of MessageTrait<Message> {
 fn print_messages_recursive(messages: Array<Message>, index: u32) {
     match gas::withdraw_gas() {
         Option::Some(_) => {},
-        Option::None(_) => {
+        Option::None => {
             let mut data = ArrayTrait::<felt252>::new();
             data.append('OOG');
             panic(data);
@@ -56,7 +56,7 @@ impl MessagePrintImpl of PrintTrait<Message> {
     fn print(self: Message) {
         ('___MESSAGE BEGINS___').print();
         match self {
-            Message::Quit(()) => ('Quit').print(),
+            Message::Quit => ('Quit').print(),
             Message::Echo(msg) => msg.print(),
             Message::Move((a, b)) => {
                 a.print();

--- a/exercises/enums/enums3.cairo
+++ b/exercises/enums/enums3.cairo
@@ -62,7 +62,7 @@ fn test_match_message_call() {
     state.process(Message::ChangeColor((255, 0, 255)));
     state.process(Message::Echo('hello world'));
     state.process(Message::Move(Point { x: 10, y: 15 }));
-    state.process(Message::Quit(()));
+    state.process(Message::Quit);
 
     assert(state.color == (255, 0, 255), 'wrong color');
     assert(state.position.x == 10, 'wrong x position');

--- a/exercises/options/options2.cairo
+++ b/exercises/options/options2.cairo
@@ -10,7 +10,7 @@ use debug::PrintTrait;
 fn test_options() {
     let target = 'starklings';
     let optional_some = Option::Some(target);
-    let optional_none: Option<felt252> = Option::None(());
+    let optional_none: Option<felt252> = Option::None;
     simple_option(optional_some);
     simple_option(optional_none);
 }

--- a/exercises/options/options3.cairo
+++ b/exercises/options/options3.cairo
@@ -19,7 +19,7 @@ fn display_grades(student: @Student, index: usize) {
     // running recursive functions.
     match gas::withdraw_gas() {
         Option::Some(_) => {},
-        Option::None(_) => {
+        Option::None => {
             let mut data = ArrayTrait::new();
             data.append('Out of gas');
             panic(data);
@@ -65,10 +65,10 @@ fn test_all_defined() {
 fn test_some_empty() {
     let courses = array![
         Option::Some('A'),
-        Option::None(()),
+        Option::None,
         Option::Some('B'),
         Option::Some('C'),
-        Option::None(()),
+        Option::None,
     ];
     let mut student = Student { name: 'Bob', courses: courses };
     display_grades(@student, 0);


### PR DESCRIPTION
A small set of edits to syntax of enums and options exercises with empty 'unit type' `()`

My personal solutions compiled with these small edits

I intend to also submit a PR to the Cairo Book to make the same readability changes for unit types in [6.1 'The option enum'](https://book.cairo-lang.org/ch06-01-enums.html#the-option-enum-and-its-advantages) and [6.2 'The Match Control Flow Construct'](https://book.cairo-lang.org/ch06-02-the-match-control-flow-construct.html)
Thank you for providing and maintaining this excellent resource