### PR TITLE
docs(README.md): add license badge under project title

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 # STARKLINGS
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 ![STARKLINGS](./.github/hero-banner.svg)
 
 ### An interactive tutorial to get you up and running with Cairo and Starknet


### PR DESCRIPTION
## Current behavior

The README currently starts directly with the project title and description,
but does not include any visual badges for the license or contribution info.

## New behavior

Added standard badge directly under the main README title:

[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)

- The **License** badge links to the LICENSE file.

## Breaking changes

None — documentation-only change.

## Other information

- This PR is purely cosmetic and improves the first impression for new visitors.
- Makes the project README look consistent with other open-source projects.
