### PR TITLE
add do not change comment

### DIFF
--- a/exercises/move_semantics/move_semantics2.cairo
+++ b/exercises/move_semantics/move_semantics2.cairo
@@ -5,6 +5,7 @@
 fn main() {
     let arr0 = array![];
 
+    // Do not change the following line!
     let mut _arr1 = fill_arr(arr0);
 
     // Do not change the following line!


### PR DESCRIPTION
I tried to fix this issue by changing arr0 to arr0.clone(), but the compiler complained that the code should not be modified.  It's better to add a comment for hinting that code should be unchanged. 